### PR TITLE
Fix typo in auth

### DIFF
--- a/src/config/auth.rst
+++ b/src/config/auth.rst
@@ -275,7 +275,7 @@ Authentication Configuration
         not ``true``. Used for :ref:`api/auth/proxy`. ::
 
             [couch_httpd_auth]
-            x_auth_roles = X-Auth-CouchDB-Token
+            x_auth_token = X-Auth-CouchDB-Token
 
     .. config:option:: x_auth_username :: Proxy Auth username header
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Changed reference from x_auth_roles to x_auth_token to match section.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-documentation/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Documentation is written and is accurate;
- [ ] `make check` passes with no errors
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the commit hash once this PR is rebased and merged
